### PR TITLE
 ber decoding for non short tag number

### DIFF
--- a/source/codecs/ber.ts
+++ b/source/codecs/ber.ts
@@ -561,9 +561,6 @@ class BERElement extends X690Element {
                 this.tagNumber <<= 7;
                 this.tagNumber |= (bytes[i] & 0x7F);
             }
-            if (this.tagNumber <= 31) {
-                throw new errors.ASN1Error("ASN.1 tag number could have been encoded in short form.", this);
-            }
         }
 
         // Length

--- a/test/ber/constructed.test.js
+++ b/test/ber/constructed.test.js
@@ -169,4 +169,16 @@ describe("Basic Encoding Rules", () => {
         outerElement.inner = innerElement;
         expect(outerElement.inner.objectIdentifier.nodes).toEqual([ 1, 5, 7 ]);
     });
+
+    it("decodes non short tag number", () => {
+        const data = new Uint8Array([
+            0x1F, 0x04, 0x03, 0x01, 0x02, 0x03,
+        ]);
+
+        const element = new asn1.BERElement();
+        element.fromBytes(data);
+        expect(element.octetString).toEqual(new Uint8Array([
+            0x01, 0x02, 0x03,
+        ]));
+    });
 });


### PR DESCRIPTION
BER decos will fail such as: 0x1F, 0x04, 0x03, 0x01, 0x02, 0x03
Yes, this byte sequence can be minimized: 0x04, 0x03, 0x01, 0x02, 0x03

I undertand that the minimize rule is applied to DER, not BER.

ref:
http://luca.ntop.org/Teaching/Appunti/asn1.html

~~~
DER adds the following restrictions to the rules given in Section 3:

When the length is between 0 and 127, the short form of length must be used
~~~

## Checklist
<!-- Remove items that do not apply. For completed items, change [ ] to [x]. -->

- [ x] Tests and/or benchmarks are included.
- [ ] Documentation is changed or added.
