### PR TITLE
Fix exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -50,6 +50,8 @@
     "types": "./dist/index.d.mts",
     "version": "11.0.4",
     "exports": {
+        ".": "./dist/index.mjs",
         "./functional": "./dist/functional.mjs"
     }
 }
+


### PR DESCRIPTION
For `"moduleResoultion": "NodeNext"` `main` and `types` are ignored when you also define `exports`