### PR TITLE
Set up Cursor Cloud dev environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,14 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+`asn1-ts` (`@wildboar/asn1`) is a pure, dependency-free TypeScript library for ASN.1 X.690 encoding/decoding (BER/CER/DER). There are **no runtime services, databases, or network dependencies** — "running" the product means building the library and exercising its codecs from a JS runtime.
+
+Standard commands live in `package.json` `scripts` and `.github/workflows/nodejs.yml`. Key points:
+
+- Build/type-check (`npm run build`, i.e. `tsc`) is the closest thing to a lint step — there is no separate lint script. `tsconfig.json` uses very strict settings, so the build fails on unused locals, etc.
+- Tests use the native Node runner: `npm test` (`node --test`). Tests import from the compiled `dist/`, so **you must run `npm run build` before `npm test`**. The update script only installs deps; it does not build.
+- Node 22+ is required (CI matrix is Node 22.x and 25.x). The dev toolchain pins `typescript ^6` and `@types/node ^25`.
+- Source is ESM-only `.mts` under `source/`; compiled output goes to `dist/` (gitignored). Public entry is `dist/index.mjs`; a secondary `./functional` export maps to `dist/functional.mjs`.
+- Optional alternate-runtime checks (not needed for the primary Node path, and Bun/Deno are not installed by the update script): `npm run buntest` (Bun) and `npm run denocheck` (Deno).
+- Quick sanity check of the library: construct a `DERElement`, set a value (e.g. `el.integer = 42`, or `el.objectIdentifier = ObjectIdentifier.fromParts([1,2,840,113549])`), call `el.toBytes()`, then decode with a fresh `DERElement().fromBytes(...)`. Note OIDs are built via `ObjectIdentifier.fromParts([...])`, not the constructor.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for `asn1-ts` in Cursor Cloud and documents durable, non-obvious guidance for future agents.

`asn1-ts` (`@wildboar/asn1`) is a pure, dependency-free TypeScript library for ASN.1 X.690 encoding/decoding (BER/CER/DER). There are no runtime services, databases, or network dependencies — so environment setup is just the Node/npm toolchain.

## Changes

- Add `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering: build-before-test ordering, that `npm run build` (`tsc`) is the effective lint step, Node 22+ requirement, ESM-only `.mts` layout, and the `ObjectIdentifier.fromParts([...])` gotcha.

## Environment

- Update script (runs on VM startup): `npm ci`
- Node `v22.14.0`, npm `10.9.7`, TypeScript `6.0.2`

## Verification

| Step | Command | Result |
|------|---------|--------|
| Install | `npm ci` | 3 packages, 0 vulnerabilities |
| Build / type-check | `npm run build` | success |
| Tests | `npm test` | 609 passed, 1 skipped, 0 failed |

Hello-world (core encode/decode round-trip):

```
INTEGER 42 -> DER: 02012a            Decoded INTEGER: 42
OID 1.2.840.113549 -> DER: 06062a864886f70d   Decoded OID: 1.2.840.113549
UTF8String -> DER: 0c0d48656c6c6f2c2041534e2e3121   Decoded UTF8String: Hello, ASN.1!
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-03b1ef8e-18bb-4125-8579-401cdd40d547?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-03b1ef8e-18bb-4125-8579-401cdd40d547&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

